### PR TITLE
Default to window-based capture resolution; add --width/--height override (fixes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ python scripts/play.py --process '<game_executable_name>.exe'
 
 The `--process` parameter must be the exact executable name of the game you want to play. You can find it by right-clicking on the game process in Windows Task Manager (Ctrl+Shift+Esc), and selecting `Properties`. The process name should be in the `General` tab and end with `.exe`.
 
+By default, screen capture uses the game window resolution. You can override it with `--width` and `--height`:
+```bash
+python scripts/play.py --process '<game_executable_name>.exe' --width 1920 --height 1080
+```
+
 <!-- TODO # Paper and Citation
 
 If you find our work useful, please consider citing us!

--- a/scripts/play.py
+++ b/scripts/play.py
@@ -19,6 +19,8 @@ parser = argparse.ArgumentParser(description="VLM Inference")
 parser.add_argument("--process", type=str, default="celeste.exe", help="Game to play")
 parser.add_argument("--allow-menu", action="store_true", help="Allow menu actions (Disabled by default)")
 parser.add_argument("--port", type=int, default=5555, help="Port for model server")
+parser.add_argument("--width", type=int, default=None, help="Override capture width")
+parser.add_argument("--height", type=int, default=None, help="Override capture height")
 
 args = parser.parse_args()
 
@@ -92,6 +94,8 @@ for i in range(3):
 
 env = GamepadEnv(
     game=args.process,
+    image_width=args.width,
+    image_height=args.height,
     game_speed=1.0,
     env_fps=60,
     async_mode=True,


### PR DESCRIPTION
Fix screen capture to default to the game window resolution and correct dxcam region format (fixes #10).

Changes:
- game_env.py: image_width/image_height default to None, so resolved window dimensions are used automatically
- game_env.py: move observation_space initialization after window detection so it uses resolved dimensions
- game_env.py: fix bbox/region format mismatch:
  - dxcam expects (left, top, right, bottom)
  - pyautogui expects (left, top, width, height)
  Previously both were fed the same format, which could result in an invalid region or partial capture.
- play.py: add --width and --height CLI args for manual override

Usage:
automatically uses window resolution:
`python scripts/play.py --process game.exe`

override with custom resolution:
`python scripts/play.py --process game.exe --width 1920 --height 1080`

Testing:
- Windows display scaling (DPI): 100%, 125%, 150%
- Tested on multiple window sizes/resolutions (e.g. 1920x1080, 2560x1440)
- Verified dxcam no longer throws "Invalid Region" and captured frames match the full game window