### PR TITLE
Fix screen capture cropping issue

### DIFF
--- a/nitrogen/game_env.py
+++ b/nitrogen/game_env.py
@@ -1,5 +1,6 @@
 import time
 import platform
+import ctypes
 
 import pyautogui
 import dxcam
@@ -21,6 +22,10 @@ import win32gui
 import win32api
 import win32con
 
+try:
+    ctypes.windll.shcore.SetProcessDpiAwareness(1)
+except Exception:
+    ctypes.windll.user32.SetProcessDPIAware()
 
 def get_process_info(process_name):
     """
@@ -468,7 +473,7 @@ class GamepadEnv(Env):
 
         self.game_window.activate()
         l, t, r, b = self.game_window.left, self.game_window.top, self.game_window.right, self.game_window.bottom
-        self.bbox = (l, t, r - l, b - t)
+        self.bbox = (l, t, r, b)
 
         # Initialize speedhack client if using DLL injection
         self.speedhack_client = xsh.Client(process_id=self.game_pid, arch=self.game_arch)


### PR DESCRIPTION
On my setup (Windows 11, RTX 4070 Ti Super), I encountered an issue where the game capture was significantly cropped (zoomed into the top-left corner).

It appears that the bounding box coordinates passed to dxcam were calculated as (left, top, width, height), which resulted in an incorrect capture region on my machine.

I modified game_env.py to pass (left, top, right, bottom) instead, which fixed the cropping issue for me.

Additionally, I added SetProcessDpiAwareness to ensure correct coordinate handling on High DPI displays, although the coordinate fix was the primary solution in my case.

<img width="1202" height="934" alt="image (98)" src="https://github.com/user-attachments/assets/712d061a-6776-465b-b122-153da0ebd18b" />
<img width="1202" height="934" alt="image (99)" src="https://github.com/user-attachments/assets/1e16b174-edf9-4874-8da2-388359e0aa8e" />