### PR TITLE
Fixing controller data alignment within padded actions tensor.

### DIFF
--- a/nitrogen/mm_tokenizers.py
+++ b/nitrogen/mm_tokenizers.py
@@ -157,6 +157,8 @@ class NitrogenTokenizer(Tokenizer):
         ), f"Action dim {n_action_dims} exceeds max allowed {self.max_action_dim}."
 
         # Pad the channel dimension
+        # [batch, 18, 21] -> [batch, 18, 25] badded by zeros on the right.
+        # Action data is left aligned here [btn[0], btn[1], ..., btn[16], j_left[0], j_left[1], j_right[0], j_right[1], 0, 0, 0, 0]
         actions = np.pad(actions, ((0, 0), (0, self.max_action_dim - n_action_dims)), "constant")
 
         # Create mask: [T, max_action_dim]
@@ -233,6 +235,10 @@ class NitrogenTokenizer(Tokenizer):
         return action
 
     def unpack_actions(self, actions):
+        # Action data is still left aligned here [btn[0], btn[1], ..., btn[16], j_left[0], j_left[1], j_right[0], j_right[1], 0, 0, 0, 0].
+        # And the dimensions are [batch, 18, 25], not [batch, 18, 21].
+        # Need to remove padding before using negative indices for extracting j_left, j_right.
+        actions = actions[:, :, :21]
         if self.old_layout:
             # Unpack the actions into j_left, j_right, buttons
             j_left = actions[:, :, :2]

--- a/nitrogen/mm_tokenizers.py
+++ b/nitrogen/mm_tokenizers.py
@@ -235,16 +235,16 @@ class NitrogenTokenizer(Tokenizer):
         return action
 
     def unpack_actions(self, actions):
-        # Action data is still left aligned here [btn[0], btn[1], ..., btn[16], j_left[0], j_left[1], j_right[0], j_right[1], 0, 0, 0, 0].
-        # And the dimensions are [batch, 18, 25], not [batch, 18, 21].
-        # Need to remove padding before using negative indices for extracting j_left, j_right.
-        actions = actions[:, :, :21]
         if self.old_layout:
             # Unpack the actions into j_left, j_right, buttons
             j_left = actions[:, :, :2]
             j_right = actions[:, :, 2:4]
             buttons = actions[:, :, 4:]
         else:
+            # Action data is still left aligned here [btn[0], btn[1], ..., btn[16], j_left[0], j_left[1], j_right[0], j_right[1], 0, 0, 0, 0].
+            # And the dimensions are [batch, 18, 25], not [batch, 18, 21].
+            # Need to remove padding before using negative indices for extracting j_left, j_right.
+            actions = actions[:, :, :21]
             # Unpack the actions into j_left, j_right, buttons
             buttons = actions[:, :, :-4]
             j_left = actions[:, :, -4:-2]


### PR DESCRIPTION
Hello MineDojo, 

I believe, there is a controller data alignment issue in _mm_tokenizers.py_ file. In _encode()_ controller data is aligned left and padded with zeros on the right. But in the _decode()_ the data is assumed to be aligned right as negative indices are used to extract j_right, j_left, and buttons.
When controller inputs are recovered after integrating noise data in _get_action()/get_action_with_cfg()_, the action tensor last dimension is 25, not 21. Quick and dirty fix is to add one line 

> actions = actions[:, :, :21]

prior to extracting _j_left_, _j_right_, and _buttons_.

Thank you!